### PR TITLE
Fix "~/.nvm/nvm.sh: No such file ..." error on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ cache:
     - ~/.nvm
 
 before_install:
-  - which nvm || curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
   - export NVM_DIR=~/.nvm
+  - which nvm || curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
   - source ~/.nvm/nvm.sh --install
   - nvm install 4.2.3
   - brew update


### PR DESCRIPTION
It seems like nvm is installed in the wrong path (`'/usr/local/opt/nvm'`) in some of the builds. This PR moves

```
export NVM_DIR=~/.nvm
```

to set the correct NVM directory before installing

```
which nvm || curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
```

to fix this.

> Ref: https://github.com/creationix/nvm#install-script
